### PR TITLE
Updates to Grunt scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ components/
 node_modules/
 style.css.map
 style.css
+style.min.css
 aws-keys.json
 hashed/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ components/
 node_modules/
 style.css.map
 style.css
-style.min.css
 aws-keys.json
 hashed/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,37 +13,67 @@ module.exports = function(grunt) {
         watch: {
             local: {
                 files: [scss, html, source],
-                tasks: ['sass', 'cssmin', 'hash', 'compile']
+                tasks: ['sass', 'cssmin', 'hash', 'compile', 'replace:local']
             },
             remote: {
                 files: [scss, html, source],
-                tasks: ['sass', 'cssmin', 'hash', 'compile', 'aws_s3']
+                tasks: ['sass', 'cssmin', 'hash', 'compile', 'replace:remote', 'aws_s3']
             }
         },
         sass: {
-          dist: {
-            options: {
-                style: 'compressed'
-            },
-            files: [{
-                expand: true,
-                cwd: dir,
-                src: '**/*.scss',
-                dest: dir,
-                ext: '.css'
-            }]
-          }
+            dist: {
+                options: {
+                    style: 'compressed'
+                },
+                files: [{
+                    expand: true,
+                    cwd: dir,
+                    src: '**/*.scss',
+                    dest: dir,
+                    ext: '.css'
+                }]
+            }
         },
         cssmin: {
-          target: {
-            files: [{
-              expand: true,
-              cwd: dir,
-              src: '*.css',
-              dest: dir,
-              ext: '.min.css'
-            }]
-          }
+            target: {
+                files: [{
+                    expand: true,
+                    cwd: dir,
+                    src: '*.css',
+                    dest: dir,
+                    ext: '.min.css'
+                }]
+            }
+        },
+        replace: {
+            local: {
+                options: {
+                    patterns: [{
+                        match: /@@assetPath@@/g,
+                        replacement: 'http://localhost:8000/' + dir + '/hashed'
+                    }]
+                },
+                files: [{
+                    expand: true,
+                    cwd: dir,
+                    src: '**/source.json',
+                    dest: dir,
+                }]
+            },
+            remote: {
+                options: {
+                    patterns: [{
+                        match: /@@assetPath@@/g,
+                        replacement: 'http://interactive.guim.co.uk/' + remoteDir + '/hashed'
+                    }]
+                },
+                files: [{
+                    expand: true,
+                    cwd: dir,
+                    src: '**/source.json',
+                    dest: dir
+                }]
+            }
         },
         connect: {
             server: {
@@ -138,6 +168,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('compile', function() {
         grunt.file.expand({}, dir + '*').forEach(function(path) {
+            console.log(source);
             var html = grunt.file.read(path + '/index.html');
             var css = grunt.file.read(path + '/style.min.css');
             var jsonFile = path + '/source.json';

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,11 +13,11 @@ module.exports = function(grunt) {
         watch: {
             local: {
                 files: [scss, html, source],
-                tasks: ['sass', 'hash', 'compile']
+                tasks: ['sass', 'cssmin', 'hash', 'compile']
             },
             remote: {
                 files: [scss, html, source],
-                tasks: ['sass', 'hash', 'compile', 'aws_s3']
+                tasks: ['sass', 'cssmin', 'hash', 'compile', 'aws_s3']
             }
         },
         sass: {
@@ -31,6 +31,17 @@ module.exports = function(grunt) {
                 src: '**/*.scss',
                 dest: dir,
                 ext: '.css'
+            }]
+          }
+        },
+        cssmin: {
+          target: {
+            files: [{
+              expand: true,
+              cwd: dir,
+              src: '*.css',
+              dest: dir,
+              ext: '.min.css'
             }]
           }
         },
@@ -128,7 +139,7 @@ module.exports = function(grunt) {
     grunt.registerTask('compile', function() {
         grunt.file.expand({}, dir + '*').forEach(function(path) {
             var html = grunt.file.read(path + '/index.html');
-            var css = grunt.file.read(path + '/style.css');
+            var css = grunt.file.read(path + '/style.min.css');
             var jsonFile = path + '/source.json';
             var localDir = path.split('/')[1];
             var project = grunt.file.readJSON(jsonFile);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -177,7 +177,6 @@ module.exports = function(grunt) {
 
     grunt.registerTask('compile', function() {
         grunt.file.expand({}, dir + '*').forEach(function(path) {
-            console.log(source);
             var html = grunt.file.read(path + '/index.html');
             var css = grunt.file.read(path + '/style.css');
             var jsonFile = path + '/source.json';

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,11 +13,11 @@ module.exports = function(grunt) {
         watch: {
             local: {
                 files: [scss, html, source],
-                tasks: ['sass', 'cssmin', 'hash', 'compile', 'replace:local']
+                tasks: ['sass', 'autoprefixer', 'cssmin', 'hash', 'compile', 'replace:local']
             },
             remote: {
                 files: [scss, html, source],
-                tasks: ['sass', 'cssmin', 'hash', 'compile', 'replace:remote', 'aws_s3']
+                tasks: ['sass', 'autoprefixer', 'cssmin', 'hash', 'compile', 'replace:remote', 'aws_s3']
             }
         },
         sass: {
@@ -31,6 +31,16 @@ module.exports = function(grunt) {
                     src: '**/*.scss',
                     dest: dir,
                     ext: '.css'
+                }]
+            }
+        },
+        autoprefixer: {
+            dist: {
+                files: [{
+                    expand: true,
+                    cwd: dir,
+                    src: 'style.css',
+                    dest: dir
                 }]
             }
         },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,8 +50,7 @@ module.exports = function(grunt) {
                     expand: true,
                     cwd: dir,
                     src: '*.css',
-                    dest: dir,
-                    ext: '.min.css'
+                    dest: dir
                 }]
             }
         },
@@ -180,7 +179,7 @@ module.exports = function(grunt) {
         grunt.file.expand({}, dir + '*').forEach(function(path) {
             console.log(source);
             var html = grunt.file.read(path + '/index.html');
-            var css = grunt.file.read(path + '/style.min.css');
+            var css = grunt.file.read(path + '/style.css');
             var jsonFile = path + '/source.json';
             var localDir = path.split('/')[1];
             var project = grunt.file.readJSON(jsonFile);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-json-replace": "^0.1.2",
     "grunt-prompt": "^1.3.0",
     "grunt-replace": "^0.9.2",
-    "grunt-sass": "^0.18.0",
+    "grunt-sass": "^1.0.0",
     "jit-grunt": "^0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-autoprefixer": "^3.0.0",
     "grunt-aws-s3": "^0.9.4",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt-json-generator": "^0.1.0",
     "grunt-json-replace": "^0.1.2",
     "grunt-prompt": "^1.3.0",
+    "grunt-replace": "^0.9.2",
     "grunt-sass": "^0.18.0",
     "jit-grunt": "^0.9.0"
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "grunt-aws-s3": "^0.9.4",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "^0.7.0",
+    "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-hash": "^0.5.0",
     "grunt-json-generator": "^0.1.0",


### PR DESCRIPTION
A bunch of updates to the Grunt scripts that I've been meaning to do for a while

* **CSS is properly minified** Sass compressed is good and all but we were serving a bunch of comments from our `pasteup components`. Now we don't do that.
* **Allow use of `@@assetPath@@`** This will serve correct urls when you're developing locally or remotely.
* **Autoprefixer** Although the css3 mixins partial is still here, it will be removed so we can autoprefix all the things.