### PR TITLE
Get more specific with our background colouring

### DIFF
--- a/shared/_mixins.scss
+++ b/shared/_mixins.scss
@@ -1,7 +1,7 @@
 // Base
 // Description: A few base rules to get us started
 @mixin base($containerName, $c-background: #dedede) {
-    ##{$containerName} {
+    ##{$containerName}.fc-container--thrasher {
         background-color: $c-background;
 
         .fc-item {
@@ -21,7 +21,7 @@
 // Rule
 // Description: Place a rule on top of the thrasher on all breakpoints
 @mixin rule($containerName, $c-rule: #005689) {
-    ##{$containerName} {
+    ##{$containerName}.fc-container--thrasher {
         @include mq($until: tablet) {
             border-top: 1px solid $c-rule;
         }


### PR DESCRIPTION
This should prevent cross contamination of properties that was happening when a thrasher had the same name as a regular container on the page. Example of what used to happen...

![image 2015-06-04 at 11 11 42 am](https://cloud.githubusercontent.com/assets/1607666/7986389/44183e22-0acf-11e5-9e6e-65ac0a1993e3.png)
