### PR TITLE
Remove AWS keys and use InteractivesProd Janus credentials instead

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,15 +8,11 @@ module.exports = function(grunt) {
           secretAccessKey: aws.AWSSecretKey,
           region: 'us-east-1'
       };
-      grunt.log.writeln('PERMANENT KEYS');
-      grunt.log.writeln(awsOptions);
     } else {
       var awsOptions = {
           awsProfile: 'interactivesProd',
           region: 'us-east-1'
       };
-      grunt.log.writeln('JANUS KEYS');
-      grunt.log.writeln(awsOptions);
     }
 
     var newDir = grunt.option('folderName');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,24 @@
 module.exports = function(grunt) {
     require('jit-grunt')(grunt);
 
+    if (grunt.file.exists('aws-keys.json')) {
+      var aws = grunt.file.readJSON('aws-keys.json');
+      var awsOptions = {
+          accessKeyId: aws.AWSAccessKeyID,
+          secretAccessKey: aws.AWSSecretKey,
+          region: 'us-east-1'
+      };
+      grunt.log.writeln('PERMANENT KEYS');
+      grunt.log.writeln(awsOptions);
+    } else {
+      var awsOptions = {
+          awsProfile: 'interactivesProd',
+          region: 'us-east-1'
+      };
+      grunt.log.writeln('JANUS KEYS');
+      grunt.log.writeln(awsOptions);
+    }
+
     var newDir = grunt.option('folderName');
     var dir =  'embeds/' + (grunt.option('folderName') ? grunt.option('folderName') : '');
     var scss = 'embeds/' + (grunt.option('folderName') ? grunt.option('folderName') + '/*.scss' : '**/*.scss');
@@ -98,10 +116,7 @@ module.exports = function(grunt) {
             }
         },
         aws_s3: {
-            options: {
-                awsProfile: 'interactivesProd',
-                region: 'us-east-1'
-            },
+            options: awsOptions,
             production: {
                 options: {
                     bucket: 'gdn-cdn',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,6 @@
 module.exports = function(grunt) {
     require('jit-grunt')(grunt);
 
-    var aws = grunt.file.readJSON('aws-keys.json');
     var newDir = grunt.option('folderName');
     var dir =  'embeds/' + (grunt.option('folderName') ? grunt.option('folderName') : '');
     var scss = 'embeds/' + (grunt.option('folderName') ? grunt.option('folderName') + '/*.scss' : '**/*.scss');
@@ -100,8 +99,7 @@ module.exports = function(grunt) {
         },
         aws_s3: {
             options: {
-                accessKeyId: aws.AWSAccessKeyID,
-                secretAccessKey: aws.AWSSecretKey,
+                awsProfile: 'interactivesProd',
                 region: 'us-east-1'
             },
             production: {
@@ -156,19 +154,19 @@ module.exports = function(grunt) {
                             type: 'input',
                             message: 'Fallback URL',
                             default: 'https://www.theguardian.com'
-                        }, 
-                        {  
+                        },
+                        {
                             config: 'snap.headline',
                             type: 'input',
                             message: 'Headline',
                             default: 'The Guardian'
-                        }, 
-                        {  
+                        },
+                        {
                             config: 'snap.trailText',
                             type: 'input',
                             message: 'Trail Text',
                             default: 'Latest news, sport and comment from the Guardian'
-                        }  
+                        }
                     ]
                 }
             }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To run locally, use
 grunt local --folderName=the-name-of-your-embed
 ```
 
-To run remotely, you'll need to add AWS Keys. Use [`aws-keys.example.json`](aws-keys.example.json) to create an `aws-keys.json` file and replace the default values with your key values from the `gu-aws-interactive` AWS Account. From then on use
+To run remotely, you'll need to access to Interactives Prod via Janus. With Janus credentials pasted in terminal, run
 ```
 grunt remote --folderName=the-name-of-your-embed
 ```
@@ -72,7 +72,7 @@ grunt update --folderName=the-name-of-your-embed
 
 The appropriate snapURL then needs to be added to your container using the [Facia Fronts Tool](https://fronts.code.dev-gutools.co.uk/editorial?front=thrashers). You'll need drag it in as an active link onto the clipboard, the result of which then needs to be dragged to the appropriate container. Remember to choose benthrasher from the pull down if you want it to appear on that page.
 
-You should now see your thrasher at the bottom of the [Thrasher front](http://m.code.dev-theguardian.com/thrashers) on `CODE`. 
+You should now see your thrasher at the bottom of the [Thrasher front](http://m.code.dev-theguardian.com/thrashers) on `CODE`.
 
 OR IF YOU USED benthrasher you should now see your thrasher at the bottom of the [Ben Thrasher front](http://m.code.dev-theguardian.com/benthrasher) on `CODE`.
 
@@ -113,7 +113,7 @@ Due to multiple reports of the site crashing on older devices (iPad 2s, older An
 Due to the way we inject the thrashers into `frontend` we can't add `<script>` tags in the html. These are stripped out. The work around we've come up with so far, is to have a 1x1px image with an onload event that adds a `<script>` tag.
 
 ```html
-    <img 
+    <img
         style="height:0;width:0;visibility:hidden;position:absolute;z-index: 1;"
         height="0"
         width="0"

--- a/aws-keys.example.json
+++ b/aws-keys.example.json
@@ -1,4 +1,0 @@
-{
-    "AWSAccessKeyID": "AKxxxxxxxxxx",
-    "AWSSecretKey" : "super-secret-key"
-}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-autoprefixer": "^3.0.0",
-    "grunt-aws-s3": "^0.9.4",
+    "grunt-aws-s3": "^0.14.5",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "^0.12.3",


### PR DESCRIPTION
@sammorrisdesign @blongden73 

So switching out the AWS keys in thrashers to match embeds. Both would use InteractivesProd credentials ala frontend. Already done this on Ben's embeds and worked fine. Give it a once over and let me know thoughts.
