### PR TITLE
Correct AWS credentials profile name

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
       };
     } else {
       var awsOptions = {
-          awsProfile: 'interactivesProd',
+          awsProfile: 'interactives',
           region: 'us-east-1'
       };
     }


### PR DESCRIPTION
Janus uses `interactives` as the profile name