### PR TITLE
McDesktop

### DIFF
--- a/shared/_mixins.scss
+++ b/shared/_mixins.scss
@@ -33,3 +33,19 @@
         }
     }
  }
+
+// Page skin fix
+// Substitute for the
+@mixin mc($from) {
+    @if (map-get($mq-breakpoints, $from) < map-get($mq-breakpoints, leftCol)) {
+        @include mq($from) {
+            @content;
+        }
+    } @else {
+        body:not(.has-active-pageskin) & {
+            @include mq($from) {
+                @content;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds the `mc` mixin, which is an adjustment for the `mq` mixin. It can be used exactly the same way as `mq` for media queris, but uses the new .has-active-pageskin class to shield your thrashers from pageskins' harardous effects.

Can someone else please test this in a couple of thrashers to make sure it works? This front has a pageskin for us to try stuff out on: https://m.code.dev-theguardian.com/music