### PR TITLE
add grunt task to check filesizes when deploying

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,30 @@ module.exports = function(grunt) {
     var source = 'embeds/' + (grunt.option('folderName') ? grunt.option('folderName')+ '/_source/*' : '**/source/*');
     var remoteDir = 'thrashers/' + (grunt.option('folderName') ? grunt.option('folderName') : '');
 
+    var videoMaxAssetSize = 1 * 1000 * 1000; //1MB
+    var imageMaxAssetSize = 50 * 1000; //50kb
+
     grunt.initConfig({
+        maxFilesize: {
+            videos: {
+                options: {
+                    maxBytes: videoMaxAssetSize
+                },
+                src: [source + '.mp4', source + '.mov']
+            },
+            images: {
+                options: {
+                    maxBytes: imageMaxAssetSize
+                },
+                src: [source + '.jpg', source + '.jpeg', source + '.png']
+            },
+            gif: {
+                options: {
+                    maxBytes: 1 //only tracking GIFs
+                },
+                src: [source + '.gif']
+            }
+        },
         watch: {
             local: {
                 files: [scss, html, source],
@@ -618,6 +641,6 @@ module.exports = function(grunt) {
     grunt.registerTask('update', ['prompt:input', 'write-paths']);
     grunt.registerTask('default', ['sass', 'compile']);
     grunt.registerTask('local', ['connect', 'return-paths', 'update-local', 'watch:local']);
-    grunt.registerTask('remote', ['appConfigRemote', 'appConfig', 'return-paths', 'update-remote', 'watch:remote']);
+    grunt.registerTask('remote', ['appConfigRemote', 'appConfig', 'return-paths', 'maxFilesize', 'update-remote', 'watch:remote']);
     grunt.registerTask('paths', ['return-paths']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
 
     var videoMaxAssetSize = 1 * 1000 * 1000; //1MB
     var imageMaxAssetSize = 200 * 1000; //200kb
+    var maxGifSize = 1.5 * 1000; //1500kb, which should be enough for a tracking pixel
 
     grunt.initConfig({
         maxFilesize: {
@@ -41,7 +42,7 @@ module.exports = function(grunt) {
             },
             gif: {
                 options: {
-                    maxBytes: 1 //only tracking GIFs
+                    maxBytes: maxGifSize
                 },
                 src: [source + '.gif']
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
     var remoteDir = 'thrashers/' + (grunt.option('folderName') ? grunt.option('folderName') : '');
 
     var videoMaxAssetSize = 1 * 1000 * 1000; //1MB
-    var imageMaxAssetSize = 50 * 1000; //50kb
+    var imageMaxAssetSize = 200 * 1000; //200kb
 
     grunt.initConfig({
         maxFilesize: {
@@ -640,7 +640,7 @@ module.exports = function(grunt) {
     grunt.registerTask('new', ['copy', 'prompt:input', 'write-paths', 'return-paths']);
     grunt.registerTask('update', ['prompt:input', 'write-paths']);
     grunt.registerTask('default', ['sass', 'compile']);
-    grunt.registerTask('local', ['connect', 'return-paths', 'update-local', 'watch:local']);
+    grunt.registerTask('local', ['connect', 'return-paths', 'maxFilesize', 'update-local', 'watch:local']);
     grunt.registerTask('remote', ['appConfigRemote', 'appConfig', 'return-paths', 'maxFilesize', 'update-remote', 'watch:remote']);
     grunt.registerTask('paths', ['return-paths']);
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "grunt-hash": "^0.5.0",
     "grunt-json-generator": "^0.1.0",
     "grunt-json-replace": "^0.1.2",
+    "grunt-max-filesize": "^0.1.1",
     "grunt-prompt": "^1.3.0",
     "grunt-replace": "^0.9.2",
     "grunt-sass": "^1.0.0",


### PR DESCRIPTION
this will check that:
- any new video is < 1MB
- any new image is < 200kb
- you're not using gifs!

and will fail the grunt task if you exceed the limits

![img](https://media.giphy.com/media/dMYVHzANYb9p6/giphy.gif)