### PR TITLE
Add useHtml flag to render html, css and js on app fronts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -398,13 +398,13 @@ module.exports = function(grunt) {
                             message: 'Add client side gradient (improve text contrast)'
                         },
                         {
-                            config: 'appConfig.useHtml',
+                            config: 'appConfig.html',
                             type: 'list',
                             default: false,
                             message: 'Use HTML, CSS and JavaScript on apps?'['red'].bold,
                             choices: [
-                                { name:'Use fallback image on apps', value: false },
-                                { name:'Use HTML, CSS and JavaScript on apps', value: true }
+                                { name:'Use fallback image on apps', value: "" },
+                                { name:'Use HTML, CSS and JavaScript on apps', value: defaultFromObject("html", "") }
                             ]
                         }
                     ],
@@ -512,8 +512,12 @@ module.exports = function(grunt) {
             return defaultVal;
         }
 
-        var object = grunt.file.readJSON(path).app;
-        if(object && object[key]) {
+        var object = grunt.file.readJSON(path);
+        var app = object.app;
+
+        if (app && app[key]) {
+            return app[key];
+        } else if (key === 'html') {
             return object[key];
         }
         return defaultVal;
@@ -545,7 +549,7 @@ module.exports = function(grunt) {
         var buttonTextColour = grunt.config('appConfig.buttonTextColour');
         var hideGuardianRoundel = grunt.config('appConfig.hideGuardianRoundel');
         var imageGradient = grunt.config('appConfig.imageGradient');
-        var useHtml = grunt.config('appConfig.useHtml');
+        var html = grunt.config('appConfig.html');
 
         var app = {};
         if (layout) app.layout = layout;
@@ -571,7 +575,7 @@ module.exports = function(grunt) {
         if(hideGuardianRoundel) app.hideGuardianRoundel = hideGuardianRoundel;
         if (url) app.url = url;
         if (imageGradient) app.imageGradient = imageGradient;
-        app.useHtml = useHtml;
+        app.html = html;
 
         return app;
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,23 +213,18 @@ module.exports = function(grunt) {
                             config: 'appConfig.image',
                             type: 'input',
                             default: defaultFromObject("image", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Image URL (leave blank to use the default card image)',
-                            when: fallbackImage
-                        },
+                            message: 'OPTIONAL: '['red'].bold + 'Image URL (leave blank to use the default card image)'                        },
                         {
                             config: 'appConfig.url',
                             type: 'input',
                             default: defaultFromObject("url", null),
-                            message: 'OPTIONAL: '['red'].bold + 'URL override (leave blank to take user to default card)',
-                            when: fallbackImage
+                            message: 'OPTIONAL: '['red'].bold + 'URL override (leave blank to take user to default card)'
                         },
                         {
                             config: 'appConfig.title',
                             type: 'input',
                             default: defaultFromObject("title", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Thrasher title (leave blank to use the default card title)',
-                            when: fallbackImage
-
+                            message: 'OPTIONAL: '['red'].bold + 'Thrasher title (leave blank to use the default card title)'
                         },
                         {
                             config: 'appConfig.titleFont',
@@ -248,8 +243,7 @@ module.exports = function(grunt) {
                                 '---',
                                 { name:'Display Sans', value: 'display-sans' },
                                 '---'
-                            ],
-                            when: fallbackImage
+                            ]
                         },
                         {
                             config: 'appConfig.titleSize',
@@ -257,8 +251,7 @@ module.exports = function(grunt) {
                             default: defaultFromObject("titleSize", null),
                             message: 'OPTIONAL: '['red'].bold + 'Thrasher title size (in density independent pixels)',
                             validate: validateInputSize,
-                            filter: sizeAsInt,
-                            when: fallbackImage
+                            filter: sizeAsInt
                         },
                         {
                             config: 'appConfig.titleColour',
@@ -266,15 +259,13 @@ module.exports = function(grunt) {
                             default: defaultFromObject("titleColour", 'FFFFFF'),
                             message: 'OPTIONAL: '['red'].bold + 'Thrasher title text colour (default white)' + ' RGB'['red'].bold,
                             validate: validateInputColour,
-                            filter: hexToColour,
-                            when: fallbackImage
+                            filter: hexToColour
                         },
                         {
                             config: 'appConfig.trail',
                             type: 'input',
                             default: defaultFromObject("trail", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Trail text (blank to hide)',
-                            when: defaultLayoutAndFallback
+                            message: 'OPTIONAL: '['red'].bold + 'Trail text (blank to hide)'
                         },
                         {
                             config: 'appConfig.trailFont',
@@ -370,15 +361,13 @@ module.exports = function(grunt) {
                             config: 'appConfig.hideGuardianRoundel',
                             type: 'confirm',
                             default: defaultFromObject("hideGuardianRoundel", false),
-                            message: 'Hide Guardian Roundel',
-                            when: defaultLayoutAndFallback
+                            message: 'Hide Guardian Roundel'
                         },
                         {
                             config: 'appConfig.buttonText',
                             type: 'input',
                             default: defaultFromObject("buttonText", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Button text (default "View Now")',
-                            when: defaultLayoutAndFallback
+                            message: 'OPTIONAL: '['red'].bold + 'Button text (default "View Now")'
                         },
                         {
                             config: 'appConfig.buttonBackgroundColour',
@@ -386,8 +375,7 @@ module.exports = function(grunt) {
                             default: defaultFromObject("buttonBackgroundColour", null),
                             message: 'OPTIONAL: '['red'].bold + 'Button '+'BACKGROUND'['blue'].bold+' colour' + ' RGB'['red'].bold,
                             validate: validateInputColour,
-                            filter: hexToColour,
-                            when: defaultLayoutAndFallback
+                            filter: hexToColour
                         },
                         {
                             config: 'appConfig.buttonTextColour',
@@ -395,27 +383,26 @@ module.exports = function(grunt) {
                             default: defaultFromObject("buttonTextColour", null),
                             message: 'OPTIONAL: '['red'].bold + 'Button '+'TEXT'['blue'].bold+' colour' + ' RGB'['red'].bold,
                             validate: validateInputColour,
-                            filter: hexToColour,
-                            when: defaultLayoutAndFallback
-                        }
-                    ],
-                    then: function() { grunt.task.run('confirmAppConfig'); }
-                }
-            },
-            appConfigHtml: {
-                options: {
-                    questions: [
+                            filter: hexToColour
+                        },
+                        {
+                            config: 'appConfig.imageGradient',
+                            type: 'confirm',
+                            default: defaultFromObject("imageGradient", false),
+                            message: 'Add client side gradient (improve text contrast)'
+                        },
                         {
                             config: 'appConfig.useHtml',
                             type: 'list',
-                            default: defaultFromObject("useHtml", false),
+                            default: false,
                             message: 'Use HTML, CSS and JavaScript on apps?'['red'].bold,
                             choices: [
                                 { name:'Use fallback image on apps', value: false },
                                 { name:'Use HTML, CSS and JavaScript on apps', value: true }
                             ]
-                        },
-                    ]
+                        }
+                    ],
+                    then: function() { grunt.task.run('confirmAppConfig'); }
                 }
             },
             appConfigLayouts: {
@@ -425,12 +412,10 @@ module.exports = function(grunt) {
                             config: 'appConfig.layout',
                             type: 'list',
                             default: defaultFromObject("layout", 'default'),
-                            message: 'Which layout should this thrasher use? ' ['red'].bold + 'SEE GITHUB DOCS FOR EXAMPLES' ['blue'].bold,
-                            choices: [
+                            message: 'Which layout should this thrasher use? ' ['red'].bold + 'SEE GITHUB DOCS FOR EXAMPLES',                            choices: [
                                 { name:'Layout 1: Default thrasher layout', value: 'default' },
                                 { name:'Layout 2: Headline, right aligned', value: 'headline-right-aligned' },
-                            ],
-                            when: fallbackImage
+                            ]
                         }
                     ],
                     then: function() { grunt.task.run(['prompt:appConfig']); }
@@ -480,7 +465,7 @@ module.exports = function(grunt) {
         // Overwrite header logger for nicer formatted output
         global['headerLogger'] = grunt.log.header;
         grunt.log.header = function() {};
-        grunt.task.run(['prompt:appConfigHtml']);
+        grunt.log.writeln('SEE GITHUB DOCUMENTATION FOR ILLUSTRATED EXAMPLES'['blue'].bold);
         grunt.task.run(['prompt:appConfigLayouts']);
     });
 
@@ -531,16 +516,7 @@ module.exports = function(grunt) {
         return grunt.config('appConfig.layout') == "default"
     }
 
-    function fallbackImage() {
-        return !grunt.config('appConfig.useHtml');
-    }
-
-    function defaultLayoutAndFallback() {
-        return defaultLayout() && fallbackImage();
-    }
-
     function getAppConfig() {
-        var useHtml = grunt.config('appConfig.useHtml');
         var layout = grunt.config('appConfig.layout');
         var title = grunt.config('appConfig.title');
         var titleFont = grunt.config('appConfig.titleFont');
@@ -561,9 +537,10 @@ module.exports = function(grunt) {
         var buttonBackgroundColour = grunt.config('appConfig.buttonBackgroundColour');
         var buttonTextColour = grunt.config('appConfig.buttonTextColour');
         var hideGuardianRoundel = grunt.config('appConfig.hideGuardianRoundel');
+        var imageGradient = grunt.config('appConfig.imageGradient');
+        var useHtml = grunt.config('appConfig.useHtml');
 
         var app = {};
-        if (useHtml) app.useHtml = useHtml;
         if (layout) app.layout = layout;
         if (title) app.title = title;
         if (titleFont) app.titleFont = titleFont;
@@ -586,6 +563,8 @@ module.exports = function(grunt) {
         }
         if(hideGuardianRoundel) app.hideGuardianRoundel = hideGuardianRoundel;
         if (url) app.url = url;
+        if (imageGradient) app.imageGradient = imageGradient;
+        app.useHtml = useHtml;
 
         return app;
     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,7 +213,8 @@ module.exports = function(grunt) {
                             config: 'appConfig.image',
                             type: 'input',
                             default: defaultFromObject("image", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Image URL (leave blank to use the default card image)'                        },
+                            message: 'OPTIONAL: '['red'].bold + 'Image URL (leave blank to use the default card image)'
+                        },
                         {
                             config: 'appConfig.url',
                             type: 'input',
@@ -265,7 +266,8 @@ module.exports = function(grunt) {
                             config: 'appConfig.trail',
                             type: 'input',
                             default: defaultFromObject("trail", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Trail text (blank to hide)'
+                            message: 'OPTIONAL: '['red'].bold + 'Trail text (blank to hide)',
+                            when: defaultLayout
                         },
                         {
                             config: 'appConfig.trailFont',
@@ -361,13 +363,15 @@ module.exports = function(grunt) {
                             config: 'appConfig.hideGuardianRoundel',
                             type: 'confirm',
                             default: defaultFromObject("hideGuardianRoundel", false),
-                            message: 'Hide Guardian Roundel'
+                            message: 'Hide Guardian Roundel',
+                            when: defaultLayout
                         },
                         {
                             config: 'appConfig.buttonText',
                             type: 'input',
                             default: defaultFromObject("buttonText", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Button text (default "View Now")'
+                            message: 'OPTIONAL: '['red'].bold + 'Button text (default "View Now")',
+                            when: defaultLayout
                         },
                         {
                             config: 'appConfig.buttonBackgroundColour',
@@ -375,7 +379,8 @@ module.exports = function(grunt) {
                             default: defaultFromObject("buttonBackgroundColour", null),
                             message: 'OPTIONAL: '['red'].bold + 'Button '+'BACKGROUND'['blue'].bold+' colour' + ' RGB'['red'].bold,
                             validate: validateInputColour,
-                            filter: hexToColour
+                            filter: hexToColour,
+                            when: defaultLayout
                         },
                         {
                             config: 'appConfig.buttonTextColour',
@@ -383,7 +388,8 @@ module.exports = function(grunt) {
                             default: defaultFromObject("buttonTextColour", null),
                             message: 'OPTIONAL: '['red'].bold + 'Button '+'TEXT'['blue'].bold+' colour' + ' RGB'['red'].bold,
                             validate: validateInputColour,
-                            filter: hexToColour
+                            filter: hexToColour,
+                            when: defaultLayout
                         },
                         {
                             config: 'appConfig.imageGradient',
@@ -412,7 +418,8 @@ module.exports = function(grunt) {
                             config: 'appConfig.layout',
                             type: 'list',
                             default: defaultFromObject("layout", 'default'),
-                            message: 'Which layout should this thrasher use? ' ['red'].bold + 'SEE GITHUB DOCS FOR EXAMPLES',                            choices: [
+                            message: 'Which layout should this thrasher use? ' ['red'].bold + 'SEE GITHUB DOCS FOR EXAMPLES',
+                            choices: [
                                 { name:'Layout 1: Default thrasher layout', value: 'default' },
                                 { name:'Layout 2: Headline, right aligned', value: 'headline-right-aligned' },
                             ]

--- a/README.md
+++ b/README.md
@@ -110,9 +110,7 @@ will display like this on apps:
 
 ### Using HTML, CSS and JavaScript thrashers on iOS and Android fronts
 
-Setting the `useHtml` field to `true` will render a webview on Android & iOS fronts. Setting to `false` (the default option) will display the fallback image.
-
-This feature will allow us to show dynamic web content on mobile fronts. It's important to test on both iOS/Android platforms when setting `useHtml` to `true`, there's likely to be some browser differences and some links may be handled differently.
+It's important to test on both iOS/Android platforms when using html rather than the fallback image. There's likely to be some browser differences and links may be handled differently.
 
 For advice on how to test/develop for apps please contact the apps team.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ It should show as `snap json.html`
 
 You can then drag that link into the thrasher container on the front you want the thrasher to appear on.
 
-#### Display on Apps
+### Display on Apps
 
 You'll be prompted to provide an app-specific config when running `grunt remote` with the `--folderName=` parameter. If you wish to update the app config without running grunt remote, you can run `grunt appConfig --folderName=<FOLDER>`
 
@@ -107,6 +107,14 @@ For example, football weekly, which displays like this on desktop:
 will display like this on apps:
 
 ![Drag gif](doc_images/football-weekly-apps.jpg)
+
+### Using HTML, CSS and JavaScript thrashers on iOS and Android fronts
+
+Setting the `useHtml` field to `true` will render a webview on Android & iOS fronts. Setting to `false` (the default option) will display the fallback image.
+
+This feature will allow us to show dynamic web content on mobile fronts. It's important to test on both iOS/Android platforms when setting `useHtml` to `true`, there's likely to be some browser differences and some links may be handled differently.
+
+For advice on how to test/develop for apps please contact the apps team.
 
 ## Developing
 
@@ -162,13 +170,4 @@ Although the same practice applies to javascript as it does for animations and t
 ### Previewing your thrasher locally
 
 Recent versions of Chrome block `https` local requests by default. To preview your thrasher in chrome, open `chrome://flags/` and enable the "Allow invalid certificates for resources loaded from localhost" flag.
-
-
-### Using HTML, CSS and JavaScript thrashers on iOS and Android fronts
-
-Setting the `useHtml` field to `true` will render a webview on Android & iOS fronts. Setting to `false` (the default option) will display the fallback image.
-
-This feature will allow us to show dynamic web content on mobile fronts. It's important to test on both iOS/Android platforms when setting `useHtml` to `true`, there's likely to be some browser differences and some links may be handled differently.
-
-For advice on how to test/develop for apps please contact the apps team.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Thrashers
 =========
 
-Collection of special Thrasher containers/snaps for the [frontend](https://github.com/guardian/frontend) project.
+Collection of special Thrasher containers/snaps for the [frontend](https://github.com/guardian/frontend), [ios](https://github.com/guardian/ios-live) and [Android](https://github.com/guardian/android-news-app) projects.
 
 
 ## Installation
@@ -162,4 +162,13 @@ Although the same practice applies to javascript as it does for animations and t
 ### Previewing your thrasher locally
 
 Recent versions of Chrome block `https` local requests by default. To preview your thrasher in chrome, open `chrome://flags/` and enable the "Allow invalid certificates for resources loaded from localhost" flag.
+
+
+### Using HTML, CSS and JavaScript thrashers on iOS and Android fronts
+
+Setting the `useHtml` field to `true` will render a webview on Android & iOS fronts. Setting to `false` (the default option) will display the fallback image.
+
+This feature will allow us to show dynamic web content on mobile fronts. It's important to test on both iOS/Android platforms when setting `useHtml` to `true`, there's likely to be some browser differences and some links may be handled differently.
+
+For advice on how to test/develop for apps please contact the apps team.
 

--- a/source.json
+++ b/source.json
@@ -4,6 +4,5 @@
   "refreshStatus": true,
   "url": "http://www.theguardian.com",
   "headline": "The Guardian",
-  "trailText": "Latest news, sport and comment from the Guardian",
-  "useHtml": false
+  "trailText": "Latest news, sport and comment from the Guardian"
 }

--- a/source.json
+++ b/source.json
@@ -4,5 +4,6 @@
   "refreshStatus": true,
   "url": "http://www.theguardian.com",
   "headline": "The Guardian",
-  "trailText": "Latest news, sport and comment from the Guardian"
+  "trailText": "Latest news, sport and comment from the Guardian",
+  "useHtml": false
 }


### PR DESCRIPTION
Adding a new `html` field to tell the apps to render a webview and reuse the thrasher html, css and js.

If empty (default), the apps will render thrashers as images like they have been. 

<pre>
{
   "html": "",
    "previous": "",
    "refreshStatus": true,
    "url": "https://www.theguardian.com",
    "headline": "The Guardian",
    "trailText": "Latest news, sport and comment from the Guardian",
    "app": {
        "layout": "default",
        "titleFont": "egypt-regular",
        "titleColour": "#FFFFFF",
        "buttonTextColour": "#FFFFFF",
        "buttonBackgroundColour": "#FFFFFF",
        "hideKicker": true,
        "hideGuardianRoundel": true,
        "imageGradient": true,
        <b>"html": "" </b>
    }
}
</pre>