### PR TITLE
Update securedrop link

### DIFF
--- a/embeds/political_transparency/index.html
+++ b/embeds/political_transparency/index.html
@@ -43,7 +43,7 @@
 
 				<span class="read-more-target">
 
-					<p>Contact <strong><a href="https://www.theguardian.com/profile/christopher-knaus" target="_blank">Christopher Knaus</a></strong> by email at christopher.knaus[at]guardian.co.uk or via <strong><a href="https://signal.org/" target="_blank">Signal</a></strong> on +61422283681 (Signal only) or using <strong><a href="https://securedrop.theguardian.com/">SecureDrop</a></strong>. Information about how to contact the Guardian securely can be found <strong><a href="https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely" target="_blank">here.</a></strong></p>
+					<p>Contact <strong><a href="https://www.theguardian.com/profile/christopher-knaus" target="_blank">Christopher Knaus</a></strong> by email at christopher.knaus[at]guardian.co.uk or via <strong><a href="https://signal.org/" target="_blank">Signal</a></strong> on +61422283681 (Signal only) or using <strong><a href="https://www.theguardian.com/securedrop">SecureDrop</a></strong>. Information about how to contact the Guardian securely can be found <strong><a href="https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely" target="_blank">here.</a></strong></p>
 
 				</span>
 


### PR DESCRIPTION
The securedrop landing page is moving onto theguardian.com domain. This PR updates the link in the political transparency thrasher.