### PR TITLE
Fix certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ aws-keys.json
 hashed/
 .idea/
 /package-lock.json
+certs

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,6 +125,9 @@ module.exports = function(grunt) {
             server: {
                 options: {
                     protocol: 'https',
+                    key: grunt.file.read('./certs/localhost-key.pem'),
+                    cert: grunt.file.read('./certs/localhost.pem'),
+                    ca: grunt.file.read('./certs/rootCA.pem'),
                     middleware: function (connect, options, middlewares) {
                         middlewares.unshift(function (req, res, next) {
                             res.setHeader('Access-Control-Allow-Origin', '*');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,443 +26,450 @@ module.exports = function(grunt) {
     var imageMaxAssetSize = 300 * 1000; //200kb
     var maxGifSize = 5000 * 1000; //1MB, which should be enough for a tracking pixel
 
-    grunt.initConfig({
-        maxFilesize: {
-            videos: {
-                options: {
-                    maxBytes: videoMaxAssetSize
+    try {
+        grunt.initConfig({
+            maxFilesize: {
+                videos: {
+                    options: {
+                        maxBytes: videoMaxAssetSize
+                    },
+                    src: [source + '.mp4', source + '.mov']
                 },
-                src: [source + '.mp4', source + '.mov']
+                images: {
+                    options: {
+                        maxBytes: imageMaxAssetSize
+                    },
+                    src: [source + '.jpg', source + '.jpeg', source + '.png']
+                },
+                gif: {
+                    options: {
+                        maxBytes: maxGifSize
+                    },
+                    src: [source + '.gif']
+                }
             },
-            images: {
-                options: {
-                    maxBytes: imageMaxAssetSize
+            watch: {
+                local: {
+                    files: [scss, html, source],
+                    tasks: ['update-local']
                 },
-                src: [source + '.jpg', source + '.jpeg', source + '.png']
+                remote: {
+                    files: [scss, html, source],
+                    tasks: ['update-remote']
+                }
             },
-            gif: {
-                options: {
-                    maxBytes: maxGifSize
-                },
-                src: [source + '.gif']
-            }
-        },
-        watch: {
-            local: {
-                files: [scss, html, source],
-                tasks: ['update-local']
+            sass: {
+                dist: {
+                    options: {
+                        style: 'compressed'
+                    },
+                    files: [{
+                        expand: true,
+                        cwd: dir,
+                        src: '**/*.scss',
+                        dest: dir,
+                        ext: '.css'
+                    }]
+                }
             },
-            remote: {
-                files: [scss, html, source],
-                tasks: ['update-remote']
-            }
-        },
-        sass: {
-            dist: {
-                options: {
-                    style: 'compressed'
-                },
-                files: [{
-                    expand: true,
-                    cwd: dir,
-                    src: '**/*.scss',
-                    dest: dir,
-                    ext: '.css'
-                }]
-            }
-        },
-        autoprefixer: {
-            dist: {
-                files: [{
-                    expand: true,
-                    cwd: dir,
-                    src: 'style.css',
-                    dest: dir
-                }]
-            }
-        },
-        cssmin: {
-            target: {
-                files: [{
-                    expand: true,
-                    cwd: dir,
-                    src: '*.css',
-                    dest: dir
-                }]
-            }
-        },
-        replace: {
-            local: {
-                options: {
-                    patterns: [{
-                        match: /@@assetPath@@/g,
-                        replacement: 'https://localhost:8000/' + dir + '/hashed'
+            autoprefixer: {
+                dist: {
+                    files: [{
+                        expand: true,
+                        cwd: dir,
+                        src: 'style.css',
+                        dest: dir
+                    }]
+                }
+            },
+            cssmin: {
+                target: {
+                    files: [{
+                        expand: true,
+                        cwd: dir,
+                        src: '*.css',
+                        dest: dir
+                    }]
+                }
+            },
+            replace: {
+                local: {
+                    options: {
+                        patterns: [{
+                            match: /@@assetPath@@/g,
+                            replacement: 'https://localhost:8000/' + dir + '/hashed'
+                        }]
+                    },
+                    files: [{
+                        expand: true,
+                        cwd: dir,
+                        src: ['**/source.json', '**/hashed/*.js'],
+                        dest: dir,
                     }]
                 },
-                files: [{
-                    expand: true,
-                    cwd: dir,
-                    src: ['**/source.json', '**/hashed/*.js'],
-                    dest: dir,
-                }]
-            },
-            remote: {
-                options: {
-                    patterns: [{
-                        match: /@@assetPath@@/g,
-                        replacement: 'https://interactive.guim.co.uk/' + remoteDir + '/hashed'
+                remote: {
+                    options: {
+                        patterns: [{
+                            match: /@@assetPath@@/g,
+                            replacement: 'https://interactive.guim.co.uk/' + remoteDir + '/hashed'
+                        }]
+                    },
+                    files: [{
+                        expand: true,
+                        cwd: dir,
+                        src: '**/source.json',
+                        dest: dir
                     }]
+                }
+            },
+            connect: {
+                server: {
+                    options: {
+                        protocol: 'https',
+                        key: grunt.file.read('./certs/localhost-key.pem'),
+                        cert: grunt.file.read('./certs/localhost.pem'),
+                        ca: grunt.file.read('./certs/rootCA.pem'),
+                        middleware: function (connect, options, middlewares) {
+                            middlewares.unshift(function (req, res, next) {
+                                res.setHeader('Access-Control-Allow-Origin', '*');
+                                res.setHeader('Access-Control-Allow-Methods', '*');
+                                return next();
+                            });
+                            return middlewares;
+                        }
+                    }
+                }
+            },
+            aws_s3: {
+                options: awsOptions,
+                production: {
+                    options: {
+                        bucket: 'gdn-cdn',
+                    },
+                    files: [{
+                        expand: true,
+                        cwd: dir,
+                        src: ['**/source.json'],
+                        dest: remoteDir,
+                        params: {
+                            CacheControl: 'max-age=60'
+                        }
+                    },{
+                        expand: true,
+                        cwd: dir,
+                        src: ['**/hashed/*'],
+                        dest: remoteDir,
+                        params: {
+                            CacheControl: 'max-age=2678400'
+                        }
+                    }]
+                }
+            },
+            hash: {
+                options: {
+                    mapping: dir + '/hashmap.json',
+                    flatten: true
                 },
-                files: [{
-                    expand: true,
-                    cwd: dir,
-                    src: '**/source.json',
-                    dest: dir
-                }]
-            }
-        },
-        connect: {
-            server: {
-                options: {
-                    protocol: 'https',
-                    key: grunt.file.read('./certs/localhost-key.pem'),
-                    cert: grunt.file.read('./certs/localhost.pem'),
-                    ca: grunt.file.read('./certs/rootCA.pem'),
-                    middleware: function (connect, options, middlewares) {
-                        middlewares.unshift(function (req, res, next) {
-                            res.setHeader('Access-Control-Allow-Origin', '*');
-                            res.setHeader('Access-Control-Allow-Methods', '*');
-                            return next();
-                        });
-                        return middlewares;
-                    }
+                source: {
+                    src: dir + '/_source/*',
+                    dest: dir + '/hashed/'
                 }
-            }
-        },
-        aws_s3: {
-            options: awsOptions,
-            production: {
-                options: {
-                    bucket: 'gdn-cdn',
+            },
+            copy: {
+                main: {
+                    files: [{
+                        expand: true,
+                        flatten: true,
+                        src: ['template/*'],
+                        dest: 'embeds/' + newDir
+                    }]
+                }
+            },
+            prompt: {
+                input: {
+                    options: {
+                        questions: [
+                            {
+                                config: 'snap.url',
+                                type: 'input',
+                                message: 'Fallback URL',
+                                default: 'https://www.theguardian.com'
+                            },
+                            {
+                                config: 'snap.headline',
+                                type: 'input',
+                                message: 'Headline',
+                                default: 'The Guardian'
+                            },
+                            {
+                                config: 'snap.trailText',
+                                type: 'input',
+                                message: 'Trail Text',
+                                default: 'Latest news, sport and comment from the Guardian'
+                            }
+                        ]
+                    }
                 },
-                files: [{
-                    expand: true,
-                    cwd: dir,
-                    src: ['**/source.json'],
-                    dest: remoteDir,
-                    params: {
-                        CacheControl: 'max-age=60'
+                appConfig: {
+                    options: {
+                        questions: [
+                            {
+                                config: 'appConfig.image',
+                                type: 'input',
+                                default: defaultFromObject("image", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Image URL (leave blank to use the default card image)'
+                            },
+                            {
+                                config: 'appConfig.tabletImage',
+                                type: 'input',
+                                default: defaultFromObject("tabletImage", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Image URL for tablets only (leave blank to fallback on image or card image)'
+                            },
+                            {
+                                config: 'appConfig.url',
+                                type: 'input',
+                                default: defaultFromObject("url", null),
+                                message: 'OPTIONAL: '['red'].bold + 'URL override (leave blank to take user to default card)'
+                            },
+                            {
+                                config: 'appConfig.title',
+                                type: 'input',
+                                default: defaultFromObject("title", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Thrasher title (leave blank to use the default card title)'
+                            },
+                            {
+                                config: 'appConfig.titleFont',
+                                type: 'list',
+                                default: defaultFromObject("titleFont", 'egypt-regular'),
+                                message: 'Thrasher title typeface',
+                                choices: [
+                                    { name:'DE1 Display Egyptian Thin', value: 'egypt-thin' },
+                                    { name:'DE2 Display Egyptian Light', value: 'egypt-light' },
+                                    { name:'DE3 Display Egyptian Regular', value: 'egypt-regular'},
+                                    { name:'DE4 Display Egyptian Medium', value: 'egypt-medium' },
+                                    { name:'DE6 Display Egyptian Bold', value: 'egypt-bold' },
+                                    '---',
+                                    { name:'Agate Regular', value: 'agate-regular' },
+                                    { name:'Agate Bold', value: 'agate-bold' },
+                                    '---',
+                                    { name:'Display Sans', value: 'display-sans' },
+                                    '---'
+                                ]
+                            },
+                            {
+                                config: 'appConfig.titleSize',
+                                type: 'input',
+                                default: defaultFromObject("titleSize", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Thrasher title size (in density independent pixels)',
+                                validate: validateInputSize,
+                                filter: sizeAsInt
+                            },
+                            {
+                                config: 'appConfig.titleColour',
+                                type: 'input',
+                                default: defaultFromObject("titleColour", 'FFFFFF'),
+                                message: 'OPTIONAL: '['red'].bold + 'Thrasher title text colour (default white)' + ' RGB'['red'].bold,
+                                validate: validateInputColour,
+                                filter: hexToColour
+                            },
+                            {
+                                config: 'appConfig.trail',
+                                type: 'input',
+                                default: defaultFromObject("trail", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Trail text (blank to hide)',
+                                when: defaultLayout
+                            },
+                            {
+                                config: 'appConfig.trailFont',
+                                type: 'list',
+                                default: defaultFromObject("trailFont", 'egypt-regular'),
+                                message: 'Trail typeface',
+                                choices: [
+                                    { name:'DE1 Display Egyptian Thin', value: 'egypt-thin' },
+                                    { name:'DE2 Display Egyptian Light', value: 'egypt-light' },
+                                    { name:'DE3 Display Egyptian Regular', value: 'egypt-regular'},
+                                    { name:'DE4 Display Egyptian Medium', value: 'egypt-medium' },
+                                    { name:'DE6 Display Egyptian Bold', value: 'egypt-bold' },
+                                    '---',
+                                    { name:'Agate Regular', value: 'agate-regular' },
+                                    { name:'Agate Bold', value: 'agate-bold' },
+                                    '---',
+                                    { name:'Display Sans', value: 'display-sans' },
+                                    '---'
+                                ],
+                                when: function() { return grunt.config('appConfig.trail') != null }
+                            },
+                            {
+                                config: 'appConfig.trailSize',
+                                type: 'input',
+                                default: defaultFromObject("trailSize", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Trail text size (in density independent pixels)',
+                                validate: validateInputSize,
+                                filter: sizeAsInt,
+                                when: function() { return grunt.config('appConfig.trail') != null }
+                            },
+                            {
+                                config: 'appConfig.trailColour',
+                                type: 'input',
+                                default: defaultFromObject("trailColour", 'FFFFFF'),
+                                message: 'OPTIONAL: '['red'].bold + 'Trail text colour (default white)' + ' RGB'['red'].bold,
+                                validate: validateInputColour,
+                                filter: hexToColour,
+                                when: function() { return grunt.config('appConfig.trail') != null }
+                            },
+                            {
+                                config: 'appConfig.kickerHide',
+                                type: 'confirm',
+                                default: defaultFromObject("kickerHide", false),
+                                message: 'Hide kicker',
+                                when: defaultLayout
+                            },
+                            {
+                                config: 'appConfig.kicker',
+                                type: 'input',
+                                default: defaultFromObject("kicker", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Kicker text (leave blank to use default card section)',
+                                when: function() { !grunt.config('appConfig.kickerHide') }
+                            },
+                            {
+                                config: 'appConfig.kickerColour',
+                                type: 'input',
+                                default: defaultFromObject("kickerColour", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Kicker text colour (leave blank to use default)' + ' RGB'['red'].bold,
+                                validate: validateInputColour,
+                                filter: hexToColour,
+                                when: function() { !grunt.config('appConfig.kickerHide') }
+                            },
+                            {
+                                config: 'appConfig.kickerFont',
+                                type: 'list',
+                                default: defaultFromObject("kickerFont", 'egypt-regular'),
+                                message: 'Kicker typeface',
+                                choices: [
+                                    { name:'DE1 Display Egyptian Thin', value: 'egypt-thin' },
+                                    { name:'DE2 Display Egyptian Light', value: 'egypt-light' },
+                                    { name:'DE3 Display Egyptian Regular', value: 'egypt-regular'},
+                                    { name:'DE4 Display Egyptian Medium', value: 'egypt-medium' },
+                                    { name:'DE6 Display Egyptian Bold', value: 'egypt-bold' },
+                                    '---',
+                                    { name:'Agate Regular', value: 'agate-regular' },
+                                    { name:'Agate Bold', value: 'agate-bold' },
+                                    '---',
+                                    { name:'Display Sans', value: 'display-sans' },
+                                    '---'
+                                ],
+                                when: function() { !grunt.config('appConfig.kickerHide') }
+                            },
+                            {
+                                config: 'appConfig.kickerSize',
+                                type: 'input',
+                                default: defaultFromObject("kickerSize", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Kicker text size (in density independent pixels)',
+                                validate: validateInputSize,
+                                filter: sizeAsInt,
+                                when: function() { !grunt.config('appConfig.kickerHide') }
+                            },
+                            {
+                                config: 'appConfig.hideGuardianRoundel',
+                                type: 'confirm',
+                                default: defaultFromObject("hideGuardianRoundel", false),
+                                message: 'Hide Guardian Roundel',
+                                when: defaultLayout
+                            },
+                            {
+                                config: 'appConfig.buttonText',
+                                type: 'input',
+                                default: defaultFromObject("buttonText", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Button text (default "View Now")',
+                                when: defaultLayout
+                            },
+                            {
+                                config: 'appConfig.buttonBackgroundColour',
+                                type: 'input',
+                                default: defaultFromObject("buttonBackgroundColour", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Button '+'BACKGROUND'['blue'].bold+' colour' + ' RGB'['red'].bold,
+                                validate: validateInputColour,
+                                filter: hexToColour,
+                                when: defaultLayout
+                            },
+                            {
+                                config: 'appConfig.buttonTextColour',
+                                type: 'input',
+                                default: defaultFromObject("buttonTextColour", null),
+                                message: 'OPTIONAL: '['red'].bold + 'Button '+'TEXT'['blue'].bold+' colour' + ' RGB'['red'].bold,
+                                validate: validateInputColour,
+                                filter: hexToColour,
+                                when: defaultLayout
+                            },
+                            {
+                                config: 'appConfig.imageGradient',
+                                type: 'confirm',
+                                default: defaultFromObject("imageGradient", false),
+                                message: 'Add client side gradient (improve text contrast)'
+                            },
+                            {
+                                config: 'appConfig.html',
+                                type: 'list',
+                                default: false,
+                                message: 'Use HTML, CSS and JavaScript on apps?'['red'].bold,
+                                choices: [
+                                    { name:'Use fallback image on apps', value: "" },
+                                    { name:'Use HTML, CSS and JavaScript on apps', value: defaultFromObject("html", "") }
+                                ]
+                            }
+                        ],
+                        then: function() { grunt.task.run('confirmAppConfig'); }
                     }
-                },{
-                    expand: true,
-                    cwd: dir,
-                    src: ['**/hashed/*'],
-                    dest: remoteDir,
-                    params: {
-                        CacheControl: 'max-age=2678400'
+                },
+                appConfigLayouts: {
+                    options: {
+                        questions: [
+                            {
+                                config: 'appConfig.layout',
+                                type: 'list',
+                                default: defaultFromObject("layout", 'default'),
+                                message: 'Which layout should this thrasher use? ' ['red'].bold + 'SEE GITHUB DOCS FOR EXAMPLES',
+                                choices: [
+                                    { name:'Layout 1: Default thrasher layout', value: 'default' },
+                                    { name:'Layout 2: Headline, right aligned', value: 'headline-right-aligned' },
+                                ]
+                            }
+                        ],
+                        then: function() { grunt.task.run(['prompt:appConfig']); }
                     }
-                }]
-            }
-        },
-        hash: {
-            options: {
-                mapping: dir + '/hashmap.json',
-                flatten: true
-            },
-            source: {
-                src: dir + '/_source/*',
-                dest: dir + '/hashed/'
-            }
-        },
-        copy: {
-            main: {
-                files: [{
-                    expand: true,
-                    flatten: true,
-                    src: ['template/*'],
-                    dest: 'embeds/' + newDir
-                }]
-            }
-        },
-        prompt: {
-            input: {
-                options: {
-                    questions: [
-                        {
-                            config: 'snap.url',
-                            type: 'input',
-                            message: 'Fallback URL',
-                            default: 'https://www.theguardian.com'
-                        },
-                        {
-                            config: 'snap.headline',
-                            type: 'input',
-                            message: 'Headline',
-                            default: 'The Guardian'
-                        },
-                        {
-                            config: 'snap.trailText',
-                            type: 'input',
-                            message: 'Trail Text',
-                            default: 'Latest news, sport and comment from the Guardian'
-                        }
-                    ]
-                }
-            },
-            appConfig: {
-                options: {
-                    questions: [
-                        {
-                            config: 'appConfig.image',
-                            type: 'input',
-                            default: defaultFromObject("image", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Image URL (leave blank to use the default card image)'
-                        },
-                        {
-                            config: 'appConfig.tabletImage',
-                            type: 'input',
-                            default: defaultFromObject("tabletImage", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Image URL for tablets only (leave blank to fallback on image or card image)'
-                        },
-                        {
-                            config: 'appConfig.url',
-                            type: 'input',
-                            default: defaultFromObject("url", null),
-                            message: 'OPTIONAL: '['red'].bold + 'URL override (leave blank to take user to default card)'
-                        },
-                        {
-                            config: 'appConfig.title',
-                            type: 'input',
-                            default: defaultFromObject("title", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Thrasher title (leave blank to use the default card title)'
-                        },
-                        {
-                            config: 'appConfig.titleFont',
-                            type: 'list',
-                            default: defaultFromObject("titleFont", 'egypt-regular'),
-                            message: 'Thrasher title typeface',
-                            choices: [
-                                { name:'DE1 Display Egyptian Thin', value: 'egypt-thin' },
-                                { name:'DE2 Display Egyptian Light', value: 'egypt-light' },
-                                { name:'DE3 Display Egyptian Regular', value: 'egypt-regular'},
-                                { name:'DE4 Display Egyptian Medium', value: 'egypt-medium' },
-                                { name:'DE6 Display Egyptian Bold', value: 'egypt-bold' },
-                                '---',
-                                { name:'Agate Regular', value: 'agate-regular' },
-                                { name:'Agate Bold', value: 'agate-bold' },
-                                '---',
-                                { name:'Display Sans', value: 'display-sans' },
-                                '---'
-                            ]
-                        },
-                        {
-                            config: 'appConfig.titleSize',
-                            type: 'input',
-                            default: defaultFromObject("titleSize", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Thrasher title size (in density independent pixels)',
-                            validate: validateInputSize,
-                            filter: sizeAsInt
-                        },
-                        {
-                            config: 'appConfig.titleColour',
-                            type: 'input',
-                            default: defaultFromObject("titleColour", 'FFFFFF'),
-                            message: 'OPTIONAL: '['red'].bold + 'Thrasher title text colour (default white)' + ' RGB'['red'].bold,
-                            validate: validateInputColour,
-                            filter: hexToColour
-                        },
-                        {
-                            config: 'appConfig.trail',
-                            type: 'input',
-                            default: defaultFromObject("trail", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Trail text (blank to hide)',
-                            when: defaultLayout
-                        },
-                        {
-                            config: 'appConfig.trailFont',
-                            type: 'list',
-                            default: defaultFromObject("trailFont", 'egypt-regular'),
-                            message: 'Trail typeface',
-                            choices: [
-                                { name:'DE1 Display Egyptian Thin', value: 'egypt-thin' },
-                                { name:'DE2 Display Egyptian Light', value: 'egypt-light' },
-                                { name:'DE3 Display Egyptian Regular', value: 'egypt-regular'},
-                                { name:'DE4 Display Egyptian Medium', value: 'egypt-medium' },
-                                { name:'DE6 Display Egyptian Bold', value: 'egypt-bold' },
-                                '---',
-                                { name:'Agate Regular', value: 'agate-regular' },
-                                { name:'Agate Bold', value: 'agate-bold' },
-                                '---',
-                                { name:'Display Sans', value: 'display-sans' },
-                                '---'
-                            ],
-                            when: function() { return grunt.config('appConfig.trail') != null }
-                        },
-                        {
-                            config: 'appConfig.trailSize',
-                            type: 'input',
-                            default: defaultFromObject("trailSize", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Trail text size (in density independent pixels)',
-                            validate: validateInputSize,
-                            filter: sizeAsInt,
-                            when: function() { return grunt.config('appConfig.trail') != null }
-                        },
-                        {
-                            config: 'appConfig.trailColour',
-                            type: 'input',
-                            default: defaultFromObject("trailColour", 'FFFFFF'),
-                            message: 'OPTIONAL: '['red'].bold + 'Trail text colour (default white)' + ' RGB'['red'].bold,
-                            validate: validateInputColour,
-                            filter: hexToColour,
-                            when: function() { return grunt.config('appConfig.trail') != null }
-                        },
-                        {
-                            config: 'appConfig.kickerHide',
-                            type: 'confirm',
-                            default: defaultFromObject("kickerHide", false),
-                            message: 'Hide kicker',
-                            when: defaultLayout
-                        },
-                        {
-                            config: 'appConfig.kicker',
-                            type: 'input',
-                            default: defaultFromObject("kicker", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Kicker text (leave blank to use default card section)',
-                            when: function() { !grunt.config('appConfig.kickerHide') }
-                        },
-                        {
-                            config: 'appConfig.kickerColour',
-                            type: 'input',
-                            default: defaultFromObject("kickerColour", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Kicker text colour (leave blank to use default)' + ' RGB'['red'].bold,
-                            validate: validateInputColour,
-                            filter: hexToColour,
-                            when: function() { !grunt.config('appConfig.kickerHide') }
-                        },
-                        {
-                            config: 'appConfig.kickerFont',
-                            type: 'list',
-                            default: defaultFromObject("kickerFont", 'egypt-regular'),
-                            message: 'Kicker typeface',
-                            choices: [
-                                { name:'DE1 Display Egyptian Thin', value: 'egypt-thin' },
-                                { name:'DE2 Display Egyptian Light', value: 'egypt-light' },
-                                { name:'DE3 Display Egyptian Regular', value: 'egypt-regular'},
-                                { name:'DE4 Display Egyptian Medium', value: 'egypt-medium' },
-                                { name:'DE6 Display Egyptian Bold', value: 'egypt-bold' },
-                                '---',
-                                { name:'Agate Regular', value: 'agate-regular' },
-                                { name:'Agate Bold', value: 'agate-bold' },
-                                '---',
-                                { name:'Display Sans', value: 'display-sans' },
-                                '---'
-                            ],
-                            when: function() { !grunt.config('appConfig.kickerHide') }
-                        },
-                        {
-                            config: 'appConfig.kickerSize',
-                            type: 'input',
-                            default: defaultFromObject("kickerSize", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Kicker text size (in density independent pixels)',
-                            validate: validateInputSize,
-                            filter: sizeAsInt,
-                            when: function() { !grunt.config('appConfig.kickerHide') }
-                        },
-                        {
-                            config: 'appConfig.hideGuardianRoundel',
-                            type: 'confirm',
-                            default: defaultFromObject("hideGuardianRoundel", false),
-                            message: 'Hide Guardian Roundel',
-                            when: defaultLayout
-                        },
-                        {
-                            config: 'appConfig.buttonText',
-                            type: 'input',
-                            default: defaultFromObject("buttonText", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Button text (default "View Now")',
-                            when: defaultLayout
-                        },
-                        {
-                            config: 'appConfig.buttonBackgroundColour',
-                            type: 'input',
-                            default: defaultFromObject("buttonBackgroundColour", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Button '+'BACKGROUND'['blue'].bold+' colour' + ' RGB'['red'].bold,
-                            validate: validateInputColour,
-                            filter: hexToColour,
-                            when: defaultLayout
-                        },
-                        {
-                            config: 'appConfig.buttonTextColour',
-                            type: 'input',
-                            default: defaultFromObject("buttonTextColour", null),
-                            message: 'OPTIONAL: '['red'].bold + 'Button '+'TEXT'['blue'].bold+' colour' + ' RGB'['red'].bold,
-                            validate: validateInputColour,
-                            filter: hexToColour,
-                            when: defaultLayout
-                        },
-                        {
-                            config: 'appConfig.imageGradient',
-                            type: 'confirm',
-                            default: defaultFromObject("imageGradient", false),
-                            message: 'Add client side gradient (improve text contrast)'
-                        },
-                        {
-                            config: 'appConfig.html',
-                            type: 'list',
-                            default: false,
-                            message: 'Use HTML, CSS and JavaScript on apps?'['red'].bold,
-                            choices: [
-                                { name:'Use fallback image on apps', value: "" },
-                                { name:'Use HTML, CSS and JavaScript on apps', value: defaultFromObject("html", "") }
-                            ]
-                        }
-                    ],
-                    then: function() { grunt.task.run('confirmAppConfig'); }
-                }
-            },
-            appConfigLayouts: {
-                options: {
-                    questions: [
-                        {
-                            config: 'appConfig.layout',
-                            type: 'list',
-                            default: defaultFromObject("layout", 'default'),
-                            message: 'Which layout should this thrasher use? ' ['red'].bold + 'SEE GITHUB DOCS FOR EXAMPLES',
-                            choices: [
-                                { name:'Layout 1: Default thrasher layout', value: 'default' },
-                                { name:'Layout 2: Headline, right aligned', value: 'headline-right-aligned' },
-                            ]
-                        }
-                    ],
-                    then: function() { grunt.task.run(['prompt:appConfig']); }
-                }
-            },
-            appConfigConfirm: {
-                options: {
-                    questions: [
-                        {
-                            config: 'appConfig.confirm',
-                            type: 'confirm',
-                            default: false,
-                            message: 'Do you wish to overwrite the app config?'
-                        }
-                    ]
-                }
-            },
-            appConfigRemote: {
-                options: {
-                    questions: [
-                        {
-                            config: 'appConfig.remote',
-                            type: 'confirm',
-                            default: false,
-                            message: 'Update thrasher config for apps?'
-                        }
-                    ]
+                },
+                appConfigConfirm: {
+                    options: {
+                        questions: [
+                            {
+                                config: 'appConfig.confirm',
+                                type: 'confirm',
+                                default: false,
+                                message: 'Do you wish to overwrite the app config?'
+                            }
+                        ]
+                    }
+                },
+                appConfigRemote: {
+                    options: {
+                        questions: [
+                            {
+                                config: 'appConfig.remote',
+                                type: 'confirm',
+                                default: false,
+                                message: 'Update thrasher config for apps?'
+                            }
+                        ]
+                    }
                 }
             }
+        });
+    } catch (e) {
+        if (e.message.indexOf('/certs/localhost') > -1) {
+            throw new Error('certificates not found, run `./setup-certs.sh` from root of the projects');
         }
-    });
+        throw e;
+    }
 
     grunt.registerTask('appConfigRemote', function() {
         if(grunt.file.expand({}, dir + '*').length != 1) {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You will need
 
  * [Node.js](http://nodejs.org/)
  * [Bower](http://bower.io/)
+ * [Homebrew](https://brew.sh/)
 
 Then install the project dependencies with
 ```
@@ -21,7 +22,7 @@ and
 bower install
 ```
 
-and
+and finally this script (which may take some time to run depending on how long it takes Homebrew to update)
 ```
 ./setup-certs.sh
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ and finally this script (which may take some time to run depending on how long i
 ./setup-certs.sh
 ```
 
+N.b. if Firefox is open when installing the certificates you'll need to restart it
+
 ## Usage
 
 ### Creating your Thrasher

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ and
 bower install
 ```
 
+and
+```
+./setup-certs.sh
+```
+
 ## Usage
 
 ### Creating your Thrasher
@@ -163,9 +168,3 @@ Due to the way we inject the thrashers into `frontend` we can't add `<script>` t
 ```
 
 Although the same practice applies to javascript as it does for animations and transitions. There has to be a good reason for it to exist and they have to be incredibly light. It's also best not to require heavy libraries like `jQuery` to achieve the same results that could be done with vanilla javascript and/or micro-libraries.
-
-
-### Previewing your thrasher locally
-
-Recent versions of Chrome block `https` local requests by default. To preview your thrasher in chrome, open `chrome://flags/` and enable the "Allow invalid certificates for resources loaded from localhost" flag.
-

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
+set -e
+
 CERT_CIRECTORY="certs"
+
+echo "Creating certificate with mkcert - hold on 🚀"
 
 brew install mkcert nss
 

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CERT_CIRECTORY="certs"
+
+brew install mkcert nss
+
+# setup rootCA, if this exists it will not overwrite
+mkcert -install
+
+mkdir -p $CERT_CIRECTORY
+
+mkcert -key-file=./$CERT_CIRECTORY/localhost-key.pem -cert-file=./$CERT_CIRECTORY/localhost.pem localhost
+
+ln -s "$(mkcert -CAROOT)/rootCA.pem" ./certs/rootCA.pem

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CERT_CIRECTORY="certs"
+CERT_DIRECTORY="certs"
 
 echo "Creating certificate with mkcert - hold on 🚀"
 
@@ -11,8 +11,8 @@ brew install mkcert nss
 # setup rootCA, if this exists it will not overwrite
 mkcert -install
 
-mkdir -p $CERT_CIRECTORY
+mkdir -p $CERT_DIRECTORY
 
-mkcert -key-file=./$CERT_CIRECTORY/localhost-key.pem -cert-file=./$CERT_CIRECTORY/localhost.pem localhost
+mkcert -key-file=./$CERT_DIRECTORY/localhost-key.pem -cert-file=./$CERT_DIRECTORY/localhost.pem localhost
 
 ln -s "$(mkcert -CAROOT)/rootCA.pem" ./certs/rootCA.pem


### PR DESCRIPTION
This PR will drop the requirement for having to set Chrome to ignore localhost https certificates. I'm also presuming it will also mean you can test thrashers in Firefox more easily.

The PR creates certificates for localhost and drops them into a `certs` directory in the root of the project and uses these for `grunt-contrib-connect`.

There's a requirement on Homebrew that's been added in this PR but hopefully that's a worthwhile price to pay to fix this in all browsers forever 🤞

Tagging @guardian/guardian-design-team 