### PR TITLE
fix: remove console log

### DIFF
--- a/embeds/culture-nugget/_source/main.js
+++ b/embeds/culture-nugget/_source/main.js
@@ -1,5 +1,3 @@
-console.log('hellloo:');
-
 function findTargetContainer(container) {
     var prev = container.previousElementSibling;
     var classes = prev.classList;


### PR DESCRIPTION
## What does this change?

This is not a very helpful console log message. It is also one of the first one in the console on TheGuardian.com.

This PR removes this `hellloo:` console log. If logging is needed on production, maybe outline your needs for a global logger in the [Client-Side Infra][] discussion.

[Client-Side Infra]: https://github.com/orgs/guardian/teams/client-side-infra/discussions/13

## How to test

Open the console/developer tools on a Guardian page, you should **not** see the following:

![console log screenshot](https://user-images.githubusercontent.com/76776/94696513-052b4480-032f-11eb-98ab-34067500e140.png)
